### PR TITLE
Work around CBL/SAT vs SAT/CBL discrepancy.

### DIFF
--- a/lib/avreciever.js
+++ b/lib/avreciever.js
@@ -65,6 +65,14 @@ AVReciever.prototype.getState = function() {
         value = false;
       }
 
+      // At least one model of receiver reports its input source as "CBL/SAT",
+      // but requires it be written as "SAT/CBL". We hide that by translating
+      // from the read value here so any client code can work off the sources
+      // enum above.
+      if (value === "CBL/SAT") {
+        value = "SAT/CBL";
+      }
+
       return value;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,16 @@ describe('AVReciever', function() {
     })
   });
 
+  describe('input functions', function() {
+    it('should hide buggy CBL/SAT return value', function() {
+      return receiver.setInputSource(AVReceiver.Sources.CBL_SAT).then(function() {
+        return receiver.getInputSource().then(function(source) {
+          source.should.be.exactly(AVReceiver.Sources.CBL_SAT);
+        });
+      });
+    });
+  });
+
   describe('power functions', function() {
     it('should power off', function() {
       this.timeout(15000);


### PR DESCRIPTION
Work around the fact that the receiver (at least mine) returns 'CBL/SAT' as the input, but requires SAT/CBL be sent when changing the input. This is done by doing the translation on read so client code can work entirely with the source enum values.